### PR TITLE
allow for setting `sh` as the interpreter

### DIFF
--- a/examples/cchain_auto_git_without_llm.json
+++ b/examples/cchain_auto_git_without_llm.json
@@ -1,0 +1,17 @@
+[
+  {
+    "command": "git",
+    "arguments": ["add", "--all"],
+    "retry": 0
+  },
+  {
+    "command": "git",
+    "arguments": ["commit", "-m", "<<commit_message>>"],
+    "retry": 0
+  },
+  {
+    "command": "git",
+    "arguments": ["push"],
+    "retry": 0
+  }
+]

--- a/examples/cchain_intepreter_declaration.json
+++ b/examples/cchain_intepreter_declaration.json
@@ -1,0 +1,22 @@
+[
+  {
+    "command": "echo",
+    "arguments": ["$<<env_var_name>>"],
+    "environment_variables_override": {
+      "hello": "world"
+    },
+    "stdout_stored_to": "<<env_var_output>>",
+    "interpreter": "sh",
+    "retry": 0
+  },
+  {
+    "command": "echo",
+    "arguments": ["$<<env_var_output>>"],
+    "environment_variables_override": {
+      "world": "foobar"
+    },
+    "stdout_stored_to": null,
+    "interpreter": "sh",
+    "retry": 0
+  }
+]

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -8,6 +8,7 @@ use anyhow::{Error, Result};
 use log::{error, info};
 
 use crate::function;
+use crate::program::Interpreter;
 use crate::program::Program;
 
 fn get_paths(path: &std::path::Path) -> Vec<DirEntry> {
@@ -72,11 +73,13 @@ pub fn generate_template() {
             vec!["arg1".to_string(), "arg2".to_string()],
             Some(HashMap::new()),
             Some("<<hi>>".to_string()),
+            Some(Interpreter::Sh),
             3,
         ),
         Program::new(
             "another_command".to_string(),
             vec!["argA".to_string(), "argB".to_string()],
+            None,
             None,
             None,
             5,


### PR DESCRIPTION
```json
[
  {
    "command": "echo",
    "arguments": ["$<<env_var_name>>"],
    "environment_variables_override": {
      "hello": "world"
    },
    "stdout_stored_to": "<<env_var_output>>",
    "interpreter": "sh",
    "retry": 0
  },
  {
    "command": "echo",
    "arguments": ["$<<env_var_output>>"],
    "environment_variables_override": {
      "world": "foobar"
    },
    "stdout_stored_to": null,
    "interpreter": "sh",
    "retry": 0
  }
]
```