### PR TITLE
10 allow for removing newline characters for command outputs

### DIFF
--- a/examples/cchain_intepreter_declaration.json
+++ b/examples/cchain_intepreter_declaration.json
@@ -6,6 +6,9 @@
       "hello": "world"
     },
     "stdout_stored_to": "<<env_var_output>>",
+    "stdout_storage_options": {
+      "without_newline_characters": true
+    },
     "interpreter": "sh",
     "retry": 0
   },

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -10,6 +10,7 @@ use log::{error, info};
 use crate::function;
 use crate::program::Interpreter;
 use crate::program::Program;
+use crate::program::StdoutStorageOptions;
 
 fn get_paths(path: &std::path::Path) -> Vec<DirEntry> {
     let mut paths: Vec<DirEntry> = Vec::new();
@@ -73,12 +74,16 @@ pub fn generate_template() {
             vec!["arg1".to_string(), "arg2".to_string()],
             Some(HashMap::new()),
             Some("<<hi>>".to_string()),
+            Some(StdoutStorageOptions {
+                without_newline_characters: Some(true)
+            }),
             Some(Interpreter::Sh),
             3,
         ),
         Program::new(
             "another_command".to_string(),
             vec!["argA".to_string(), "argB".to_string()],
+            None,
             None,
             None,
             None,


### PR DESCRIPTION
```json
[
  {
    "command": "echo",
    "arguments": ["$<<env_var_name>>"],
    "environment_variables_override": {
      "hello": "world"
    },
    "stdout_stored_to": "<<env_var_output>>",
    "stdout_storage_options": {
      "without_newline_characters": true
    },
    "interpreter": "sh",
    "retry": 0
  },
  {
    "command": "echo",
    "arguments": ["$<<env_var_output>>"],
    "environment_variables_override": {
      "world": "foobar"
    },
    "stdout_stored_to": null,
    "interpreter": "sh",
    "retry": 0
  }
]
```