### PR TITLE
14 add an option to break the chain when a command failed

### DIFF
--- a/examples/cchain_command_failure_handling.json
+++ b/examples/cchain_command_failure_handling.json
@@ -1,6 +1,6 @@
 [
   {
-    "command": "echo",
+    "command": "non-exist-command",
     "arguments": ["$<<env_var_name>>"],
     "environment_variables_override": {
       "hello": "world"
@@ -8,7 +8,7 @@
     "stdout_stored_to": "<<env_var_output>>",
     "interpreter": "sh",
     "failure_handling_options": {
-      "continue_on_failure": true
+      "exit_on_failure": false
     },
     "retry": 0
   },

--- a/examples/cchain_command_failure_handling.json
+++ b/examples/cchain_command_failure_handling.json
@@ -7,6 +7,9 @@
     },
     "stdout_stored_to": "<<env_var_output>>",
     "interpreter": "sh",
+    "failure_handling_options": {
+      "continue_on_failure": true
+    },
     "retry": 0
   },
   {

--- a/examples/cchain_stdout_storage_options.json
+++ b/examples/cchain_stdout_storage_options.json
@@ -6,6 +6,9 @@
       "hello": "world"
     },
     "stdout_stored_to": "<<env_var_output>>",
+    "stdout_storage_options": {
+      "without_newline_characters": true
+    },
     "interpreter": "sh",
     "retry": 0
   },

--- a/src/program.rs
+++ b/src/program.rs
@@ -225,7 +225,6 @@ impl Execution for Program {
     }
 
     async fn execute(&mut self) -> Result<String, anyhow::Error> {
-        info!("{:?}", self.failure_handling_options);
         // First attempt
         let (mut status, mut output_stdout) = run_attempt(self).await;
         let mut attempts = 0;

--- a/src/program.rs
+++ b/src/program.rs
@@ -187,7 +187,7 @@ impl Program {
         if let Some(options) = &self.failure_handling_options {
             if !options.continue_on_failure {
                 error!("{}", error_message);
-                panic!();
+                std::process::exit(1);
             }
         }
     }

--- a/src/program.rs
+++ b/src/program.rs
@@ -185,7 +185,7 @@ impl Program {
 
     fn apply_failure_handling_options(&self, error_message: String) {
         if let Some(options) = &self.failure_handling_options {
-            if options.continue_on_failure {
+            if !options.continue_on_failure {
                 error!("{}", error_message);
                 panic!();
             }

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::fmt::Write;
 use std::fs::canonicalize;
 use std::fs::DirEntry;
 use std::str::FromStr;
@@ -8,6 +7,7 @@ use anyhow::{Error, Result};
 use log::{error, info};
 
 use crate::function;
+use crate::program::FailureHandlingOptions;
 use crate::program::Interpreter;
 use crate::program::Program;
 use crate::program::StdoutStorageOptions;
@@ -74,15 +74,15 @@ pub fn generate_template() {
             vec!["arg1".to_string(), "arg2".to_string()],
             Some(HashMap::new()),
             Some("<<hi>>".to_string()),
-            Some(StdoutStorageOptions {
-                without_newline_characters: Some(true)
-            }),
+            Some(StdoutStorageOptions::default()),
             Some(Interpreter::Sh),
+            Some(FailureHandlingOptions::default()),
             3,
         ),
         Program::new(
             "another_command".to_string(),
             vec!["argA".to_string(), "argB".to_string()],
+            None,
             None,
             None,
             None,

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -74,9 +74,9 @@ pub fn generate_template() {
             vec!["arg1".to_string(), "arg2".to_string()],
             Some(HashMap::new()),
             Some("<<hi>>".to_string()),
-            Some(StdoutStorageOptions::default()),
+            StdoutStorageOptions::default(),
             Some(Interpreter::Sh),
-            Some(FailureHandlingOptions::default()),
+            FailureHandlingOptions::default(),
             3,
         ),
         Program::new(
@@ -84,9 +84,9 @@ pub fn generate_template() {
             vec!["argA".to_string(), "argB".to_string()],
             None,
             None,
+            StdoutStorageOptions::default(),
             None,
-            None,
-            None,
+            FailureHandlingOptions::default(),
             5,
         ),
     ];


### PR DESCRIPTION
```json
[
  {
    "command": "non-exist-command",
    "arguments": ["$<<env_var_name>>"],
    "environment_variables_override": {
      "hello": "world"
    },
    "stdout_stored_to": "<<env_var_output>>",
    "interpreter": "sh",
    "failure_handling_options": {
      "exit_on_failure": false
    },
    "retry": 0
  },
  {
    "command": "echo",
    "arguments": ["$<<env_var_output>>"],
    "environment_variables_override": {
      "world": "foobar"
    },
    "stdout_stored_to": null,
    "interpreter": "sh",
    "retry": 0
  }
]
```