### PR TITLE
log the command better. moved the start and the end of execution of a…

### DIFF
--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -121,6 +121,10 @@ impl Execution for CommandLine {
         
         // Set stdout to piped so that we can capture it
         command.stdout(std::process::Stdio::piped());
+        display_message(
+            Level::Logging, 
+            &format!("Start executing command {}", &self)
+        );
 
         // Spawn the process
         let mut child = command.spawn().map_err(|e| {
@@ -181,6 +185,9 @@ impl Execution for CommandLine {
         let collected = reader_handle
             .await
             .map_err(|e| Error::msg(format!("Reader task panicked: {}", e)))??;
+
+        // Display a message when the command finished execution successfully
+        display_message(Level::Logging, &format!("Finished executing command: {}", &self));
 
         Ok(collected)
     }

--- a/src/cli/program.rs
+++ b/src/cli/program.rs
@@ -192,7 +192,6 @@ impl Execution for Program {
                 Ok(mut output_stdout) => {
                     // On success: apply any stdout storage options
                     self.apply_stdout_storage_options(&mut output_stdout);
-                    display_message(Level::Logging, &format!("Finished executing command: {}", &self));
                     return Ok(output_stdout);
                 },
                 Err(err) => {


### PR DESCRIPTION
Moving the logics of displaying the start and the end of a command line to the Execution trait of it. It also makes sense to let the modules handle their own message display with a unified display feature. 