### PR TITLE
41 refactor the codebase

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cchain"
 version = "0.2.7"
 edition = "2021"
-description = "A command line chain execution tool"
+description = "A modern cli automation tool"
 authors =  ["Xinyu Bao <baoxinyuworks@163.com>"]
 readme = "README.md"
 repository = "https://github.com/aspadax/cchain"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cchain"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2021"
 description = "A command line chain execution tool"
 authors =  ["Xinyu Bao <baoxinyuworks@163.com>"]
@@ -19,3 +19,6 @@ regex = "1.11.1"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.138"
 tokio = { version = "1.43.0", features = ["rt-multi-thread", "process"] }
+
+[dev-dependencies]
+tempfile = "3.17.1"

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -33,6 +33,8 @@ pub enum Commands {
     /// Remove chain(s) to your bookmark
     #[clap(short_flag = 'r')]
     Remove(RemoveArguments),
+    /// Clean chain(s) that are removed/moved from the original path
+    Clean(CleanArguments),
     /// Validate the chain syntax
     Check(CheckArguments),
     /// Create a chain template
@@ -79,6 +81,10 @@ pub struct RemoveArguments {
     #[arg(short, long, group = "sources", default_value = "false")]
     pub reset: bool,
 }
+
+#[derive(Debug, Args)]
+#[command(group = clap::ArgGroup::new("sources").required(false).multiple(false))]
+pub struct CleanArguments;
 
 #[derive(Debug, Args)]
 #[command(group = clap::ArgGroup::new("sources").required(true).multiple(false))]

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -2,8 +2,7 @@ use clap::{
     builder::{
         styling::{AnsiColor, Effects},
         Styles,
-    },
-    Args, Parser, Subcommand,
+    }, crate_authors, crate_version, crate_description, Args, Parser, Subcommand
 };
 
 // Configures Clap v3-style help menu colors
@@ -14,8 +13,8 @@ const STYLES: Styles = Styles::styled()
     .placeholder(AnsiColor::Cyan.on_default());
 
 #[derive(Debug, Parser)]
-#[command(name = "cchain")]
-#[command(about = "A modern CLI automation tool")]
+#[command(name = "cchain", author = crate_authors!(), long_version = crate_version!())]
+#[command(about = crate_description!())]
 #[command(styles = STYLES)]
 pub struct Arguments {
     /// Groupped features provided by `cchain`
@@ -41,6 +40,9 @@ pub enum Commands {
     /// Generate a chain
     #[clap(short_flag = 'g')]
     Generate(GenerateArguments),
+    /// Check version info
+    #[clap(short_flag = 'v')]
+    Version(VersionArguments)
 }
 
 #[derive(Debug, Args)]
@@ -103,3 +105,7 @@ pub struct GenerateArguments {
     #[arg(group = "sources")]
     pub llm: String,
 }
+
+#[derive(Debug, Args)]
+#[command(group = clap::ArgGroup::new("sources").required(false).multiple(false))]
+pub struct VersionArguments;

--- a/src/core/command.rs
+++ b/src/core/command.rs
@@ -169,8 +169,8 @@ impl Execution<CommandLineExecutionResult> for CommandLine {
             buffer.fill(0);
             match reader.read(&mut buffer) {
                 Ok(0) => break, // EOF
-                Ok(_) => {
-                    let text = String::from_utf8_lossy(&buffer);
+                Ok(n) => {
+                    let text = String::from_utf8_lossy(&buffer[..n]);
                     display_program_output(&text);
                     collected_output.push_str(&text);
                 },

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,6 +171,50 @@ fn main() -> Result<(), Error> {
 
             return Ok(());
         },
+        Commands::Clean(_) => {
+            let invalid_paths: Vec<String> = bookmark.get_invalid_paths()?;
+            let mut cleaned_invalid_paths: usize = 0;
+
+            if invalid_paths.len() == 0 {
+                display_message(
+                    Level::Logging, 
+                    "No chains need to be cleaned. All good! 😎"
+                );
+
+                return Ok(());
+            }
+
+            for invalid_path in invalid_paths {
+                match bookmark.remove_chain_reference_by_path(&invalid_path) {
+                    Ok(_) => {
+                        cleaned_invalid_paths += 1;
+                        display_message(
+                            Level::Logging, 
+                            &format!(
+                                "Chain does no longer exist at: {}, cleaned.", 
+                                &invalid_path
+                            )
+                        );
+                    },
+                    Err(error) => display_message(
+                        Level::Error, 
+                        &format!(
+                            "Error has occurred when trying removing chain at: {} 😥", 
+                            error
+                        )
+                    ),
+                };
+            }
+
+            display_message(
+                Level::Logging, 
+                &format!(
+                    "{} invalid chains paths are cleaned from the bookmark.", 
+                    cleaned_invalid_paths
+                )
+            );
+            bookmark.save();
+        },
         Commands::Check(subcommand) => {
             // If the input is parsable into an usize, it will use it as an
             // index to the bookmark. Otherwise, it will use it as a path

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use cchain::commons::utility::{generate_template, get_paths};
 use cchain::display_control::{display_form, display_message, Level};
 use cchain::marker::reference::ChainReference;
 use cchain::{core::chain::Chain, marker::bookmark::Bookmark};
-use clap::Parser;
+use clap::{crate_version, Parser};
 
 fn main() -> Result<(), Error> {
     // Parse command line arguments
@@ -45,7 +45,7 @@ fn main() -> Result<(), Error> {
                     };
                 }
             }
-        }
+        },
         Commands::Add(subcommand) => {
             let path = Path::new(&subcommand.path);
 
@@ -124,7 +124,7 @@ fn main() -> Result<(), Error> {
             display_message(Level::Logging, "Bookmark registration is done.");
             bookmark.save();
             return Ok(());
-        }
+        },
         Commands::List(_) => {
             let references: &Vec<ChainReference> = &bookmark.get_chain_references();
             let mut form_data: Vec<Vec<String>> = Vec::new();
@@ -138,7 +138,7 @@ fn main() -> Result<(), Error> {
             }
 
             display_form(vec!["Index", "Name", "Path"], &form_data);
-        }
+        },
         Commands::Remove(subcommand) => {
             if subcommand.reset {
                 Bookmark::reset()?;
@@ -170,7 +170,7 @@ fn main() -> Result<(), Error> {
             }
 
             return Ok(());
-        }
+        },
         Commands::Check(subcommand) => {
             // If the input is parsable into an usize, it will use it as an
             // index to the bookmark. Otherwise, it will use it as a path
@@ -187,16 +187,24 @@ fn main() -> Result<(), Error> {
                     chain.validate_syntax()?;
                 }
             }
-        }
+        },
         Commands::New(subcommand) => {
             generate_template(subcommand.name.as_deref())?;
 
             return Ok(());
-        }
+        },
         Commands::Generate(_) => {
             display_message(
                 Level::Error,
                 "LLM generation feature has not yet implemented. Stay tuned. 😈",
+            );
+
+            return Ok(());
+        },
+        Commands::Version(_) => {
+            display_message(
+                Level::Logging,
+                &format!("cchain version: {}", crate_version!()),
             );
 
             return Ok(());

--- a/src/marker/reference.rs
+++ b/src/marker/reference.rs
@@ -18,6 +18,7 @@ impl ChainReference {
         Self { chain_path: path }
     }
 
+    /// Return a canonicalized path of the chain
     pub fn get_chain_path_string(&self) -> String {
         self.chain_path.clone()
     }

--- a/tests/chain_test.rs
+++ b/tests/chain_test.rs
@@ -1,0 +1,99 @@
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+    use cchain::core::{chain::Chain, traits::Execution};
+    use tempfile::NamedTempFile;
+
+    // Test that Chain can be created from a valid JSON file
+    #[test]
+    fn test_chain_creation_from_file() {
+        let programs = r#"[
+            {
+                "command": "echo",
+                "arguments": ["hello"],
+                "awaitable_variable": null,
+                "remedy_command_line": null,
+                "failure_handling_options": {
+                    "exit_on_failure": true
+                },
+                "concurrency_group": null,
+                "retry": 0
+            }
+        ]"#;
+
+        let mut temp_file = NamedTempFile::new().unwrap();
+        write!(temp_file, "{}", programs).unwrap();
+
+        let chain = Chain::from_file(temp_file.path().to_str().unwrap());
+        assert!(chain.is_ok());
+        let chain = chain.unwrap();
+        assert!(!format!("{}", chain).is_empty());
+    }
+
+    // Test that syntax validation fails when using uninitialized variables
+    #[test]
+    fn test_validate_syntax_fails_with_uninitialized_variable() {
+        let programs = r#"[
+            {
+                "command": "command-non-exist",
+                "arguments": ["$<<hello>>"],
+                "awaitable_variable": null,
+                "remedy_command_line": null,
+                "failure_handling_options": {
+                    "exit_on_failure": true
+                },
+                "concurrency_group": null,
+                "stdout_stored_to": null,
+                "retry": 0
+            },
+            {
+                "command": "echo",
+                "arguments": ["$<<hello:on_program_execution>>"],
+                "remedy_command_line": null,
+                "failure_handling_options": {
+                    "exit_on_failure": true
+                },
+                "concurrency_group": null,
+                "retry": 0
+            }
+        ]"#;
+
+        let mut temp_file = NamedTempFile::new().unwrap();
+        write!(temp_file, "{}", programs).unwrap();
+
+        let mut chain = Chain::from_file(temp_file.path().to_str().unwrap()).unwrap();
+        let result = chain.validate_syntax();
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Check is not passed. 😢"
+        );
+    }
+
+    // Test that failure count increments when a program execution fails
+    #[test]
+    fn test_program_failure_increments_counter() {
+        let programs = r#"[
+            {
+                "command": "invalid_command_that_does_not_exist",
+                "arguments": [],
+                "awaitable_variable": null,
+                "remedy_command_line": null,
+                "failure_handling_options": {
+                    "exit_on_failure": false
+                },
+                "concurrency_group": null,
+                "retry": 0
+            }
+        ]"#;
+
+        let mut temp_file = NamedTempFile::new().unwrap();
+        write!(temp_file, "{}", programs).unwrap();
+
+        let mut chain = Chain::from_file(temp_file.path().to_str().unwrap()).unwrap();
+        let result = chain.execute();
+
+        assert!(result.is_ok());
+        assert_eq!(chain.get_failed_program_execution_number(), 1);
+    }
+}

--- a/tests/command_test.rs
+++ b/tests/command_test.rs
@@ -1,0 +1,78 @@
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+    use std::collections::HashMap;
+    use cchain::core::{command::CommandLine, interpreter::Interpreter, traits::Execution};
+
+    #[test]
+    #[cfg(unix)]
+    fn test_execute_sh_command() -> Result<()> {
+        let mut cmd = CommandLine::new(
+            "printf".to_string(),
+            vec!["%s".to_string(), "test".to_string()],
+            Some(Interpreter::Sh),
+            None,
+        );
+        let results = cmd.execute()?;
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].get_output(), "test");
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_environment_variable_override() -> Result<()> {
+        let mut env_vars = HashMap::new();
+        env_vars.insert("TEST_VAR".to_string(), "success".to_string());
+        let mut cmd = CommandLine::new(
+            "sh".to_string(),
+            vec!["-c".to_string(), "echo $TEST_VAR".to_string()],
+            None,
+            Some(env_vars),
+        );
+        let results = cmd.execute()?;
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].get_output().trim(), "success");
+        Ok(())
+    }
+
+    #[test]
+    fn test_inject_value_into_arguments() -> Result<()> {
+        let mut cmd = CommandLine::new(
+            "echo".to_string(),
+            vec!["Hello, <<NAME>>!".to_string()],
+            None,
+            None,
+        );
+        cmd.inject_value_to_variables("<<NAME>>", "Alice".to_string())?;
+        assert_eq!(*cmd.get_arguments(), vec!["Hello, Alice!"]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_revise_argument_by_index() {
+        let mut cmd = CommandLine::new(
+            "echo".to_string(),
+            vec!["old".to_string()],
+            None,
+            None,
+        );
+        cmd.revise_argument_by_index(0, "new".to_string());
+        assert_eq!(*cmd.get_arguments(), vec!["new".to_string()]);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_execute_invalid_command() {
+        let mut cmd = CommandLine::new(
+            "nonexistentcommand".to_string(),
+            vec!["".to_string()],
+            None,
+            None,
+        );
+        let result = cmd.execute();
+        assert!(result.is_err());
+        let error_msg = format!("{}", result.unwrap_err());
+        assert!(error_msg.starts_with("Failed to execute Command Line"));
+    }
+}

--- a/tests/program_test.rs
+++ b/tests/program_test.rs
@@ -1,0 +1,123 @@
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use anyhow::Result;
+    use cchain::core::{command::CommandLine, interpreter::Interpreter, options::{FailureHandlingOptions, StdoutStorageOptions}, program::Program, traits::Execution};
+
+    #[test]
+    fn test_execute_success() -> Result<()> {
+        let mut program = Program::new(
+            "echo".to_string(),
+            vec!["test".to_string()],
+            None,
+            None,
+            StdoutStorageOptions::default(),
+            None,
+            FailureHandlingOptions::default(),
+            None,
+            0,
+        );
+        let result = program.execute()?;
+        assert!(!result[0].clone().get_output().is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn test_retry_failure() {
+        let mut program = Program::new(
+            "false".to_string(),
+            vec![],
+            None,
+            None,
+            StdoutStorageOptions::default(),
+            None,
+            FailureHandlingOptions::default(),
+            None,
+            2,
+        );
+        let result = program.execute();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_stdout_storage_options() -> Result<()> {
+        let mut program = Program::new(
+            "printf".to_string(),
+            vec!["test\n".to_string()],
+            None,
+            None,
+            StdoutStorageOptions {
+                without_newline_characters: true,
+            },
+            None,
+            FailureHandlingOptions::default(),
+            None,
+            0,
+        );
+        let result = program.execute()?;
+        assert_eq!(result[0].clone().get_output(), "test");
+        Ok(())
+    }
+
+    #[test]
+    fn test_execute_remedy_command_line() -> Result<()> {
+        let mut program = Program::new(
+            "echo".to_string(),
+            vec!["test".to_string()],
+            None,
+            None,
+            StdoutStorageOptions::default(),
+            None,
+            FailureHandlingOptions {
+                exit_on_failure: true,
+                remedy_command_line: Some(
+                    CommandLine::new(
+                        "echo".to_string(), 
+                        vec!["hello".to_string()], 
+                        Some(Interpreter::Sh), 
+                        None
+                    )
+                )
+            },
+            None,
+            0,
+        );
+        program.execute_remedy_command_line()?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_program_from_str() {
+        let mut program = Program::from_str("echo hello world").unwrap();
+        assert_eq!(program.get_command_line().get_command(), "echo");
+        assert_eq!(
+            program.get_command_line().get_arguments(),
+            &vec!["hello".to_string(), "world".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_get_concurrency_group() {
+        let program = Program::new(
+            "echo".to_string(),
+            vec!["${{env::TEST_ARG_FUNCTION}}".to_string()],
+            None,
+            None,
+            StdoutStorageOptions::default(),
+            None,
+            FailureHandlingOptions::default(),
+            Some(3),
+            0,
+        );
+        assert_eq!(program.get_concurrency_group(), Some(3));
+    }
+
+    #[test]
+    fn test_default_program() {
+        let program = Program::default();
+        assert_eq!(*program.get_retry(), 0);
+        assert!(program.get_awaitable_variable().is_none());
+        assert_eq!(program.get_concurrency_group(), None);
+    }
+}

--- a/tests/variable_test.rs
+++ b/tests/variable_test.rs
@@ -1,0 +1,222 @@
+#[cfg(test)]
+mod tests {
+    use cchain::variable::{Variable, VariableInitializationTime, VariableLifetime};
+
+
+    #[test]
+    fn test_extract_no_variables() {
+        let input = "No variables here";
+        assert!(Variable::extract_variable_names(input).is_empty());
+    }
+
+    #[test]
+    fn test_extract_single_variable() {
+        let input = "<<test>>";
+        assert_eq!(Variable::extract_variable_names(input), vec!["test"]);
+    }
+
+    #[test]
+    fn test_extract_multiple_variables() {
+        let input = "<<var1>> and <<var2:on_program_execution>>";
+        let vars = Variable::extract_variable_names(input);
+        assert_eq!(vars, vec!["var1", "var2:on_program_execution"]);
+    }
+
+    #[test]
+    fn test_extract_adjacent_variables() {
+        let input = "<<var1>><<var2>>";
+        let vars = Variable::extract_variable_names(input);
+        assert_eq!(vars, vec!["var1", "var2"]);
+    }
+
+    #[test]
+    fn test_parse_variables_with_different_qualifiers() {
+        let input = r#"
+            <<on_chain_var>> 
+            <<exec_var:on_program_execution>>
+            <<await_var>> 
+        "#;
+
+        let vars = Variable::parse_variables_from_str(input, 0).unwrap();
+
+        // Test OnChainStartup variable
+        assert_eq!(vars[0].get_variable_name(), "on_chain_var");
+        assert!(matches!(
+            vars[0].get_initialization_time(),
+            VariableInitializationTime::OnChainStartup(_)
+        ));
+
+        // Test OnProgramExecution variable
+        assert_eq!(vars[1].get_variable_name(), "exec_var");
+        assert!(matches!(
+            vars[1].get_initialization_time(),
+            VariableInitializationTime::OnProgramExecution(_)
+        ));
+
+        // Test Await variable (requires separate parsing via parse_await_variable)
+        let await_var = Variable::parse_await_variable("<<await_var>>", 0);
+        assert_eq!(await_var.get_variable_name(), "await_var");
+        assert_eq!(await_var.get_raw_variable_name(), "<<await_var>>");
+        assert!(matches!(
+            await_var.get_initialization_time(),
+            VariableInitializationTime::Await(_)
+        ));
+    }
+
+    #[test]
+    fn test_case_insensitive_qualifier() {
+        let input = "<<var:ON_PROGRAM_EXECUTION>>";
+        let vars = Variable::parse_variables_from_str(input, 0).unwrap();
+
+        assert!(matches!(
+            vars[0].get_initialization_time(),
+            VariableInitializationTime::OnProgramExecution(_)
+        ));
+    }
+
+    #[test]
+    fn test_invalid_qualifier_fallback() {
+        let input = "<<var:invalid_qualifier>>";
+        let vars = Variable::parse_variables_from_str(input, 0).unwrap();
+
+        assert!(matches!(
+            vars[0].get_initialization_time(),
+            VariableInitializationTime::OnChainStartup(_)
+        ));
+    }
+
+    #[test]
+    fn test_variable_name_parsing() {
+        let input = "<<namespace::var_name:on_program_execution>>";
+        let vars = Variable::parse_variables_from_str(input, 0).unwrap();
+
+        assert_eq!(vars[0].get_raw_variable_name(), input);
+        assert_eq!(vars[0].get_variable_name(), "namespace::var_name");
+        assert!(matches!(
+            vars[0].get_initialization_time(),
+            VariableInitializationTime::OnProgramExecution(_)
+        ));
+    }
+
+    #[test]
+    fn test_mixed_variable_syntax() {
+        let input = r#"
+            User <<$name>> needs <<count:on_program_execution>> items.
+            Final result: <<result>>.
+        "#;
+
+        let vars = Variable::parse_variables_from_str(input, 0).unwrap();
+        assert_eq!(vars.len(), 3);
+        assert_eq!(vars[0].get_variable_name(), "$name");
+        assert_eq!(vars[1].get_variable_name(), "count");
+        assert_eq!(vars[2].get_variable_name(), "result");
+    }
+
+    #[test]
+    fn test_parse_variables_from_str() {
+        let input = "<<var1>> <<var2:on_program_execution>>";
+        let vars = Variable::parse_variables_from_str(input, 3).unwrap();
+        assert_eq!(vars.len(), 2);
+
+        assert_eq!(vars[0].get_variable_name(), "var1");
+        assert!(matches!(
+            vars[0].get_initialization_time(),
+            VariableInitializationTime::OnChainStartup(_)
+        ));
+
+        assert_eq!(vars[1].get_variable_name(), "var2");
+        assert!(matches!(
+            vars[1].get_initialization_time(),
+            VariableInitializationTime::OnProgramExecution(_)
+        ));
+    }
+
+    #[test]
+    fn test_parse_await_variable() {
+        let var = Variable::parse_await_variable("<<await_var>>", 2);
+        assert_eq!(var.get_variable_name(), "await_var");
+        assert!(matches!(
+            var.get_initialization_time(),
+            VariableInitializationTime::Await(_)
+        ));
+    }
+
+    #[test]
+    fn test_human_readable_name() {
+        let var = Variable::new(
+            "my_variable".to_string(),
+            None,
+            None,
+            VariableInitializationTime::OnChainStartup(VariableLifetime::new(None)),
+        );
+        assert_eq!(var.get_human_readable_name(), "My Variable");
+
+        let var_custom = Variable::new(
+            "var".to_string(),
+            None,
+            Some("Custom Name".to_string()),
+            VariableInitializationTime::OnChainStartup(VariableLifetime::new(None)),
+        );
+        assert_eq!(var_custom.get_human_readable_name(), "Custom Name");
+    }
+
+    #[test]
+    fn test_register_and_get_value() {
+        let mut var = Variable::new(
+            "test".to_string(),
+            None,
+            None,
+            VariableInitializationTime::OnChainStartup(VariableLifetime::new(None)),
+        );
+        var.register_value("value");
+        assert_eq!(var.get_value().unwrap(), "value");
+    }
+
+    #[test]
+    fn test_get_uninitialized_value() {
+        let var = Variable::new(
+            "test".to_string(),
+            None,
+            None,
+            VariableInitializationTime::OnChainStartup(VariableLifetime::new(None)),
+        );
+        assert!(var.get_value().is_err());
+    }
+
+    #[test]
+    fn test_raw_variable_name() {
+        let var_chain = Variable::new(
+            "var".to_string(),
+            None,
+            None,
+            VariableInitializationTime::OnChainStartup(VariableLifetime::new(None)),
+        );
+        assert_eq!(var_chain.get_raw_variable_name(), "<<var>>");
+
+        let var_program_exec = Variable::new(
+            "var".to_string(),
+            None,
+            None,
+            VariableInitializationTime::OnProgramExecution(VariableLifetime::new(Some(1))),
+        );
+        assert_eq!(
+            var_program_exec.get_raw_variable_name(),
+            "<<var:on_program_execution>>"
+        );
+    }
+
+    #[test]
+    fn test_is_initialized() {
+        let init_on_chain = VariableInitializationTime::OnChainStartup(VariableLifetime::new(None));
+        assert!(init_on_chain.is_initialized(0));
+        assert!(!init_on_chain.is_initialized(1));
+
+        let init_on_program = VariableInitializationTime::OnProgramExecution(VariableLifetime::new(Some(2)));
+        assert!(init_on_program.is_initialized(2));
+        assert!(!init_on_program.is_initialized(1));
+
+        let init_await = VariableInitializationTime::Await(VariableLifetime::new(Some(3)));
+        assert!(init_await.is_initialized(3));
+        assert!(!init_await.is_initialized(2));
+    }
+}


### PR DESCRIPTION
New changes:
- Allow using `cchain clean` to clean up chains that are no longer on the original path from the bookmark. 
- Allow using `cchain version` or `cchain -v` to lookup the current version number.
- Added unit tests for the core codebase. 
- Addressed minor issues when parsing variables. 
- Improved `cchain check` accuracies. 
- Version number iterates to `0.2.7`