### PR TITLE
46 llm generated chain issue fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cchain"
-version = "0.2.8"
+version = "0.2.9"
 edition = "2021"
 description = "An AI-native modern cli automation tool built with Rust"
 authors =  ["Xinyu Bao <baoxinyuworks@163.com>"]

--- a/src/generations/create.rs
+++ b/src/generations/create.rs
@@ -86,10 +86,18 @@ impl ChainCreation {
         let result: String = llm.generate_json(prompt)?;
         
         // Parse the string 
-        let parsed_commands: ParsedCommands = serde_json::from_str(&result)?;
-        let commands: String = serde_json::to_string_pretty(&parsed_commands.commands)?;
+        let programs: Vec<Program> = match serde_json::from_str(&result) {
+            Ok(result) => result,
+            Err(_) => {
+                let parsed_commands: ParsedCommands = serde_json::from_str(&result)?;
+
+                parsed_commands.commands
+            }
+        };
+
+        let commands_string: String = serde_json::to_string_pretty(&programs)?;
         
-        return Ok(commands);
+        return Ok(commands_string);
     }
 
     /// Write the generated chain

--- a/src/generations/create.rs
+++ b/src/generations/create.rs
@@ -19,14 +19,25 @@ pub struct ParsedCommands {
 }
 
 pub struct ChainCreation {
-    name: Option<String>,
-    template: Vec<Program>
+    name: Option<String>
 }
 
 impl ChainCreation {
 
     pub fn new(name: Option<String>) -> Self {
-        // Create a template configuration
+        Self { name }
+    }
+
+    pub fn create_filename(&self) -> String {
+        if let Some(name) = &self.name {
+            return "cchain_".to_string() + name + ".json";
+        } else {
+            return "cchain_template.json".to_string();
+        }
+    }
+    
+    /// Get a template objects in Vec<Program>
+    pub fn get_template_objects(&self) -> Vec<Program> {
         let template = vec![
             Program::new(
                 "example_command".to_string(),
@@ -52,50 +63,29 @@ impl ChainCreation {
             ),
         ];
 
-        Self { name, template }
+        template
     }
 
-    pub fn create_filename(&self) -> String {
-        if let Some(name) = &self.name {
-            return "cchain_".to_string() + name + ".json";
-        } else {
-            return "cchain_template.json".to_string();
-        }
-    }
-
-    /// Generates a template configuration file.
-    ///
-    /// This function creates a template configuration with example commands and arguments,
-    /// serializes it to JSON, and writes it to a file named `cchain_template.json`.
+    /// Generates a template configuration.
     pub fn generate_template(&self) -> Result<String, Error> {
-        // Serialize the template to JSON
-        let template_json: String = serde_json::to_string_pretty(&self.template)?;
-
-        Ok(template_json)
+        Ok(serde_json::to_string_pretty::<Vec<Program>>(&self.get_template_objects())?)
     }
 
     /// Create a chain by using the LLM
     pub fn generate_chain(&self, request: String) -> Result<String, Error> {
+        let template = ParsedCommands { commands: self.get_template_objects() };
         let prompt: String = format!(
-            "Your request is: {}\n Generate a json by strictly following this template: ```json\n{}\n```",
+            "Your request is: {}\n Generate a json by strictly following this template: {}",
             &request,
-            self.generate_template()?
+            serde_json::to_string_pretty::<ParsedCommands>(&template)?
         );
 
         let llm = LLM::new()?;
         let result: String = llm.generate_json(prompt)?;
         
         // Parse the string 
-        let programs: Vec<Program> = match serde_json::from_str(&result) {
-            Ok(result) => result,
-            Err(_) => {
-                let parsed_commands: ParsedCommands = serde_json::from_str(&result)?;
-
-                parsed_commands.commands
-            }
-        };
-
-        let commands_string: String = serde_json::to_string_pretty(&programs)?;
+        let parsed_commands: ParsedCommands = serde_json::from_str(&result)?;
+        let commands_string: String = serde_json::to_string_pretty(&parsed_commands.commands)?;
         
         return Ok(commands_string);
     }


### PR DESCRIPTION
Fixed by using the following json structure instead of `Vec<Program>`. It turns out that LLMs were fine-tuned on fine jsons without the outermost part being an array. 
```json
commands: [
    ...some real Program object
]
```
After getting this structure from the LLM, it will access the `commands` key to get the final chain. 