### PR TITLE
Fix `on_program_execution` variables may not pass values to the subsequent variables

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cchain"
-version = "0.3.3"
+version = "0.3.31"
 edition = "2021"
 description = "An AI-native modern cli automation tool built with Rust"
 authors =  ["Xinyu Bao <baoxinyuworks@163.com>"]

--- a/src/core/command.rs
+++ b/src/core/command.rs
@@ -126,9 +126,25 @@ impl CommandLine {
         raw_variable_name: &str,
         value: String,
     ) -> Result<(), Error> {
+        // For `on_program_execution` variables, there might be subsequent variables that
+        // does not have the suffix, but are still expected to have values. 
+        // Hence, we should create two variable names to check if it is contained. 
+        let mut raw_variable_name_without_suffix: String = raw_variable_name.split(":").collect::<Vec<&str>>()[0].to_string();
+        raw_variable_name_without_suffix.push_str(">>");
+        
         for argument in &mut self.arguments {
-            if argument.contains(raw_variable_name) {
-                *argument = argument.replace(raw_variable_name, &value);
+            // If the new_argument is exactly the same as the argument, 
+            // it means that the replace has failed. 
+            // Then, we should use a modified string to replace the var. 
+            // And if that replacement still fails, it means they are not meant to be replaced
+            if argument.contains(&raw_variable_name) {
+                *argument = argument.replace(raw_variable_name, &value);    
+                continue;
+            }
+            
+            if argument.contains(&raw_variable_name_without_suffix) {
+                // Try replacing the var with a modified string
+                *argument = argument.replace(&raw_variable_name_without_suffix, &value);
             }
         }
 


### PR DESCRIPTION
1. **Version Bump**: The package version in `Cargo.toml` was updated from `0.3.3` to `0.3.31`.
2. **Variable Replacement Logic**: In `src/core/command.rs`, the logic for replacing variables in command arguments was enhanced to handle cases where variables may lack a suffix but still need replacement (e.g., `on_program_execution` variables). The code now checks for both the exact variable name and a modified version without the suffix.

### Suggested Git Commit Message:
```
Bump version to 0.3.31 and improve variable replacement logic

- Updated Cargo.toml version from 0.3.3 to 0.3.31.
- Enhanced variable substitution in command arguments to handle cases where variables may lack a suffix but still require replacement (e.g., `on_program_execution` variables).
```